### PR TITLE
Fix math functions unavailable in std namespace

### DIFF
--- a/Plugin/Source/Processors/Loss Effects/LossEffects.cpp
+++ b/Plugin/Source/Processors/Loss Effects/LossEffects.cpp
@@ -16,9 +16,9 @@ void LossEffects::init (float sampleRate, float speed, float spacing, float thic
         const auto freq = ((float) k * binWidth) + (binWidth / 2.0f);
         const auto waveNumber = MathConstants<float>::twoPi * freq / speedMetric;
 
-        const auto spacingLoss = std::expf (-1.0f * waveNumber * spacing);
-        const auto gapLoss = std::sinf (waveNumber * gap / 2.0f) / (waveNumber * gap / 2.0f);
-        const auto thicknessLoss = (1.0f - std::expf (-waveNumber * thickness)) / (waveNumber * thickness);
+        const auto spacingLoss = std::exp (-1.0f * waveNumber * spacing);
+        const auto gapLoss = std::sin (waveNumber * gap / 2.0f) / (waveNumber * gap / 2.0f);
+        const auto thicknessLoss = (1.0f - std::exp (-waveNumber * thickness)) / (waveNumber * thickness);
 
         H[k] = spacingLoss * gapLoss * thicknessLoss;
         H[order - k - 1] = H[k];
@@ -29,7 +29,7 @@ void LossEffects::init (float sampleRate, float speed, float spacing, float thic
     {
         h[n] = 0;
         for (int k = 0; k < order; k++)
-            h[n] += H[k] * std::cosf (MathConstants<float>::twoPi * (float) k * (float) n / (float) order);
+            h[n] += H[k] * std::cos (MathConstants<float>::twoPi * (float) k * (float) n / (float) order);
 
         h[n] /= (float) order;
     }


### PR DESCRIPTION
Hi, it doesn't build on Linux GCC. The `f`-suffixed functions are absent from the namespace `std`.
