### PR TITLE
fix submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/jatinchowdhury18/JUCE.git
 [submodule "Plugin/foleys_gui_magic"]
 	path = Plugin/foleys_gui_magic
-	url = https://github.com/ffAudio/foleys_gui_magic.git
+	url = https://github.com/jatinchowdhury18/foleys_gui_magic.git


### PR DESCRIPTION
First of all many thanks for this incredibly good sounding plugin.
This PR got delayed by many hours because I couldn't stop listening to my mixes trough CHOWTapeModel!  :)


I'm packaging it for NixOS and during cloning it complains: ``Unable to checkout 49c87190bcf3bd3fe1dcc281faff0793afaeb775 from https://github.com/ffAudio/foleys_gui_magic.git``
That commit [does exist](https://github.com/ffAudio/foleys_gui_magic/tree/49c87190bcf3bd3fe1dcc281faff0793afaeb775)!

@OPNA2608 remarked [on discord](https://discord.com/channels/568306982717751326/570351733780381697/786892782903754752):
> check /commit/49c87190bcf3bd3fe1dcc281faff0793afaeb775 instead, it doesn't exist on that repository
i believe they intended to point that at their own fork with that commit instead of the upstream repo, like with their JUCE submodule. fetchgit greps the configured url from .gitmodules, then inits a new repo in the submodule's intended directory and tries to fetch the specified commit from it. doing it this way makes git fail, while git's clone --recurse-submodules automagically resolves this correctly(edited)
maybe you could ask them to fix [this line](https://github.com/jatinchowdhury18/AnalogTapeModel/blob/84fe03fe6f239655faca629be0b3d5ed76fa0c32/.gitmodules#L6) and update their submodule?

TBH, I dont really get it, but his solution works, so here it is in PR form,

Thanks @OPNA2608!
