### PR TITLE
don't build VST2 by default on linux

### DIFF
--- a/Plugin/build_linux.sh
+++ b/Plugin/build_linux.sh
@@ -20,7 +20,7 @@ echo "include ../../LV2.mak" >> Builds/LinuxMakefile/Makefile
 
 (
     cd Builds/LinuxMakefile
-    CONFIG=Release make
+    CONFIG=Release make LV2 VST3 Standalone
 )
 
 rm LV2.mak


### PR DESCRIPTION
Since it requires an unfree SDK, it's a lot more practical for packagers if it does not get built by default.
