### PR TITLE
Loss Filters: make sure crossfade length doesn't underflow for large buffer sizes

### DIFF
--- a/Plugin/Source/Processors/Loss_Effects/LossFilter.cpp
+++ b/Plugin/Source/Processors/Loss_Effects/LossFilter.cpp
@@ -60,6 +60,7 @@ void LossFilter::prepare (float sampleRate, int samplesPerBlock)
 {
     fs = sampleRate;
     fadeBuffer.setSize (2, samplesPerBlock);
+    fadeLength = jmax (1024, samplesPerBlock);
 
     fsFactor = (float) fs / 44100.0f;
     curOrder = int (order * fsFactor);

--- a/Plugin/Source/Processors/Loss_Effects/LossFilter.h
+++ b/Plugin/Source/Processors/Loss_Effects/LossFilter.h
@@ -27,7 +27,7 @@ private:
     StereoIIR bumpFilter[2];
     int activeFilter = 0;
     int fadeCount = 0;
-    const int fadeLength = 1024;
+    int fadeLength = 1024;
     AudioBuffer<float> fadeBuffer;
 
     std::atomic<float>* onOff = nullptr;


### PR DESCRIPTION
Fixes #152