### PR TITLE
Issue #236 - vvtanh is macOS / iOS only

### DIFF
--- a/Plugin/Source/Processors/Hysteresis/STNModel.h
+++ b/Plugin/Source/Processors/Hysteresis/STNModel.h
@@ -137,7 +137,7 @@ public:
 
     inline void forward (const v_type* input) noexcept
     {
-#if defined(_M_ARM64) || defined(__arm64__) || defined(__aarch64__)
+#if (defined(_M_ARM64) || defined(__arm64__) || defined(__aarch64__)) && (JUCE_MAC || JUCE_IOS)
         alignas (16) double x[4];
         input[0].copyToRawArray (x);
         input[1].copyToRawArray (&x[2]);


### PR DESCRIPTION
This is untested. And another patch is needed to build the plugin on Linux aarch64.
(different module)