### PR TITLE
LV2: Support stereo mode only

### DIFF
--- a/Plugin/Source/PluginProcessor.cpp
+++ b/Plugin/Source/PluginProcessor.cpp
@@ -134,10 +134,18 @@ float ChowtapeModelAudioProcessor::calcLatencySamples() const noexcept
 
 bool ChowtapeModelAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
 {
-    return ((! layouts.getMainInputChannelSet().isDiscreteLayout())
-            && (! layouts.getMainOutputChannelSet().isDiscreteLayout())
-            && (layouts.getMainInputChannelSet() == layouts.getMainOutputChannelSet())
-            && (! layouts.getMainInputChannelSet().isDisabled()));
+    if (wrapperType == juce::AudioProcessor::WrapperType::wrapperType_LV2)
+    {
+        return ((layouts.getMainOutputChannelSet() == AudioChannelSet::stereo())
+                && (layouts.getMainInputChannelSet() == AudioChannelSet::stereo()));
+    }
+    else
+    {
+        return ((! layouts.getMainInputChannelSet().isDiscreteLayout())
+                && (! layouts.getMainOutputChannelSet().isDiscreteLayout())
+                && (layouts.getMainInputChannelSet() == layouts.getMainOutputChannelSet())
+                && (! layouts.getMainInputChannelSet().isDisabled()));
+    }
 }
 
 void ChowtapeModelAudioProcessor::processBlockBypassed (AudioBuffer<float>& buffer, MidiBuffer&)


### PR DESCRIPTION
LV2 does not support setting number of channels dynamically, so, to avoid confusing hosts with 36-channels plugin and to preserve compatibility with older LV2 plugins, the LV2 plugin now reports supporting stereo mode only.

Refs. https://github.com/jatinchowdhury18/AnalogTapeModel/issues/283